### PR TITLE
Strip shebang in `transform` hook to stop rollup from exploding

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,15 +20,32 @@ export default function shebangPlugin({ shebang, entry } = {}) {
 			}
 			return options;
 		},
-		renderChunk(code, { format, sourcemap }) {
+		transform: function transform(code) {
+			if (!shebang) return;
+
+			const index = code.indexOf(shebang);
+
+			let str = new MagicString(code);
+
+			if (index > -1) {
+				str.remove(index, index + shebang.length);
+			}
+
+			return {
+				code: str.toString(),
+				map: str.generateMap({ hires: true })
+			};
+		},
+		renderChunk(code, _, { sourcemap }) {
 			if (!shebang) return;
 
 			let str = new MagicString(code);
 			str.prepend(shebang + '\n');
+
 			return {
 				code: str.toString(),
-				map: sourcemap ? str.generateMap({ hires: true }) : undefined,
+				map: sourcemap ? str.generateMap({ hires: true }) : undefined
 			};
-		},
+		}
 	};
 }


### PR DESCRIPTION
Added a `transform` hook to strip out shebangs from files so rollup wouldn't error out.

I believe this will resolve https://github.com/palmerhq/tsdx/issues/109

Here is the error output that was occurring when trying to build:
```bash
➜ yarn build --target node
yarn run v1.15.2
warning package.json: No license field
$ tsdx build --target node
✓ Creating entry file 3.5 secs
Error when using sourcemap for reporting an error: Can't resolve original location of error.
Error when using sourcemap for reporting an error: Can't resolve original location of error.
Error when using sourcemap for reporting an error: Can't resolve original location of error.
Error when using sourcemap for reporting an error: Can't resolve original location of error.
(node:60781) UnhandledPromiseRejectionWarning: Error: Unexpected character '#' (Note that you need plugins to import files that are not JavaScript)
    at error (/Users/malves/Development/tmp/tsdx-issue/node_modules/rollup/dist/rollup.js:9236:30)
    at Module.error (/Users/malves/Development/tmp/tsdx-issue/node_modules/rollup/dist/rollup.js:12909:9)
    at tryParse (/Users/malves/Development/tmp/tsdx-issue/node_modules/rollup/dist/rollup.js:12825:16)
    at Module.setSource (/Users/malves/Development/tmp/tsdx-issue/node_modules/rollup/dist/rollup.js:13102:33)
    at Promise.resolve.catch.then.then.then (/Users/malves/Development/tmp/tsdx-issue/node_modules/rollup/dist/rollup.js:15924:20)
    at <anonymous>
(node:60781) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:60781) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Error when using sourcemap for reporting an error: Can't resolve original location of error.
✨  Done in 5.38s.
```